### PR TITLE
Use dynamic name for usage print out

### DIFF
--- a/LanternExtractor/LanternExtractor.cs
+++ b/LanternExtractor/LanternExtractor.cs
@@ -25,7 +25,8 @@ namespace LanternExtractor
 
             if (args.Length != 1)
             {
-                Console.WriteLine("Usage: lantern.exe <filename/shortname/all>");
+                string appName = AppDomain.CurrentDomain.FriendlyName;
+                Console.WriteLine($"Usage: {appName} <filename/shortname/all>");
                 return;
             }
             


### PR DESCRIPTION
### Before
```
> .\LanternExtractor.exe
Usage: lantern.exe <filename/shortname/all>
```

### After
```
> .\LanternExtractor.exe
Usage: LanternExtractor.exe <filename/shortname/all>
```

or

```
> cp .\LanternExtractor.exe .\Renamed.exe
> .\Renamed.exe
Usage: Renamed.exe <filename/shortname/all>
```

https://docs.microsoft.com/en-us/dotnet/api/system.appdomain.friendlyname