### PR TITLE
glTF and obj export - Option to export additional animations compatible with base model

### DIFF
--- a/LanternExtractor/EQ/GlobalReference.cs
+++ b/LanternExtractor/EQ/GlobalReference.cs
@@ -1,0 +1,24 @@
+﻿using LanternExtractor.EQ.Pfs;
+using LanternExtractor.EQ.Wld;
+using LanternExtractor.Infrastructure.Logger;
+using System.Collections.Generic;
+
+namespace LanternExtractor.EQ
+{
+    public sealed class GlobalReference
+    {
+        // Note: NOT thread-safe, however, outside of init, should be used
+        // read-only. If app is running multi-threaded the init happens
+        // before tasks are spun up.
+        public static WldFileCharacters CharacterWld { get; private set; }
+        public static PfsArchive CharacterWldPfsArchive { get; private set; }
+
+        public static void InitCharacterWld( PfsArchive pfsArchive, PfsFile wldFile, string rootFolder, string zoneName, 
+            WldType type, ILogger logger, Settings settings, List<WldFile> wldFilesToInject = null )
+        {
+            CharacterWld = new WldFileCharacters(wldFile, zoneName, type, logger, settings, wldFilesToInject);
+            CharacterWld.Initialize(rootFolder, false);
+            CharacterWldPfsArchive = pfsArchive;
+        }
+    }
+}

--- a/LanternExtractor/EQ/Wld/Exporters/ActorGltfExporter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/ActorGltfExporter.cs
@@ -199,6 +199,11 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
             if (skeleton == null) return;
 
+            if (settings.ExportAdditionalAnimations && wldFile.ZoneShortname != "global")
+            {
+                GlobalReference.CharacterWld.AddAdditionalAnimationsToSkeleton(skeleton);
+            }
+
             var exportFormat = settings.ExportGltfInGlbFormat ? GltfExportFormat.Glb : GltfExportFormat.GlTF;
             var gltfWriter = new GltfWriter(settings.ExportGltfVertexColors, exportFormat, logger);
             

--- a/LanternExtractor/EQ/Wld/Exporters/ActorObjExporter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/ActorObjExporter.cs
@@ -165,6 +165,11 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 return;
             }
 
+            if (settings.ExportAdditionalAnimations && wldFile.ZoneShortname != "global")
+            {
+                GlobalReference.CharacterWld.AddAdditionalAnimationsToSkeleton(skeleton);
+            }
+
             if (settings.ExportAllAnimationFrames)
             {
                 foreach (var animation in skeleton.Animations)

--- a/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
@@ -52,6 +52,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
         private readonly GltfExportFormat _exportFormat = GltfExportFormat.GlTF;
         private readonly ILogger _logger;
 
+        #region Constants
         private static readonly float MaterialRoughness = 0.9f;
         private static readonly Vector4 DefaultVertexColor = new Vector4(0f, 0f, 0f, 1f); // Black
         private static readonly string MaterialInvisName = "Invis";
@@ -91,9 +92,88 @@ namespace LanternExtractor.EQ.Wld.Exporters
              "sky"
         };
 
+        private static readonly IDictionary<string, string> AnimationDescriptions = new Dictionary<string, string>()
+        {
+            {"c01", "Combat Kick"},
+            {"c02", "Combat Piercing"},
+            {"c03", "Combat 2H Slash"},
+            {"c04", "Combat 2H Blunt"},
+            {"c05", "Combat Throwing"},
+            {"c06", "Combat 1H Slash Left"},
+            {"c07", "Combat Bash"},
+            {"c08", "Combat Hand to Hand"},
+            {"c09", "Combat Archery"},
+            {"c10", "Combat Swim Attack"},
+            {"c11", "Combat Round Kick"},
+            {"d01", "Damage 1"},
+            {"d02", "Damage 2"},
+            {"d03", "Damage from Trap"},
+            {"d04", "Drowning_Burning"},
+            {"d05", "Dying"},
+            {"l01", "Walk"},
+            {"l02", "Run"},
+            {"l03", "Jump (Running)"},
+            {"l04", "Jump (Standing)"},
+            {"l05", "Falling"},
+            {"l06", "Crouch Walk"},
+            {"l07", "Climbing"},
+            {"l08", "Crouching"},
+            {"l09", "Swim Treading"},
+            {"o01", "Idle"},
+            {"s01", "Cheer"},
+            {"s02", "Mourn"},
+            {"s03", "Wave"},
+            {"s04", "Rude"},
+            {"s05", "Yawn"},
+            {"p01", "Stand"},
+            {"p02", "Sit_Stand"},
+            {"p03", "Shuffle Feet"},
+            {"p04", "Float_Walk_Strafe"},
+            {"p05", "Kneel"},
+            {"p06", "Swim"},
+            {"p07", "Sitting"},
+            {"t01", "UNUSED????"},
+            {"t02", "Stringed Instrument"},
+            {"t03", "Wind Instrument"},
+            {"t04", "Cast Pull Back"},
+            {"t05", "Raise and Loop Arms"},
+            {"t06", "Cast Push Forward"},
+            {"t07", "Flying Kick"},
+            {"t08", "Rapid Punches"},
+            {"t09", "Large Punch"},
+            {"s06", "Nod"},
+            {"s07", "Amazed"},
+            {"s08", "Plead"},
+            {"s09", "Clap"},
+            {"s10", "Distress"},
+            {"s11", "Blush"},
+            {"s12", "Chuckle"},
+            {"s13", "Burp"},
+            {"s14", "Duck"},
+            {"s15", "Look Around"},
+            {"s16", "Dance"},
+            {"s17", "Blink"},
+            {"s18", "Glare"},
+            {"s19", "Drool"},
+            {"s20", "Kneel"},
+            {"s21", "Laugh"},
+            {"s22", "Point"},
+            {"s23", "Ponder"},
+            {"s24", "Ready"},
+            {"s25", "Salute"},
+            {"s26", "Shiver"},
+            {"s27", "Tap Foot"},
+            {"s28", "Bow"},
+            {"p08", "Stand (Arms at Sides)"},
+            {"o02", "Idle (Arms at Sides)"},
+            {"o03", "Idle (Sitting)"},
+            {"pos", "Pose"},
+            {"drf", "Pose"}
+        };
         private static readonly Matrix4x4 MirrorXAxisMatrix = Matrix4x4.CreateReflection(new Plane(1, 0, 0, 0));
         private static readonly Matrix4x4 CorrectedWorldMatrix = MirrorXAxisMatrix * Matrix4x4.CreateScale(0.1f);
-        
+        #endregion
+
         private SceneBuilder _scene;
         private IMeshBuilder<MaterialBuilder> _combinedMeshBuilder;
         private ISet<string> _meshMaterialsToSkip;
@@ -754,6 +834,10 @@ namespace LanternExtractor.EQ.Wld.Exporters
             rotationQuaternion = Quaternion.Normalize(rotationQuaternion);
             var translationVector = boneTransform.Translation.ToVector3(true);
             translationVector.Z = -translationVector.Z;
+            if (!AnimationDescriptions.TryGetValue(animationKey, out var animationDescription))
+            {
+                animationDescription = animationKey;
+            }
 
             if (staticPose)
             {
@@ -765,13 +849,13 @@ namespace LanternExtractor.EQ.Wld.Exporters
             else
             {
                 boneNode
-                    .UseScale(animationKey)
+                    .UseScale(animationDescription)
                     .WithPoint(timeMs/1000f, scaleVector);
                 boneNode
-                    .UseRotation(animationKey)
+                    .UseRotation(animationDescription)
                     .WithPoint(timeMs/1000f, rotationQuaternion);
                 boneNode
-                    .UseTranslation(animationKey)
+                    .UseTranslation(animationDescription)
                     .WithPoint(timeMs/1000f, translationVector);
             }
         }

--- a/LanternExtractor/EQ/Wld/Helpers/MeshExportHelper.cs
+++ b/LanternExtractor/EQ/Wld/Helpers/MeshExportHelper.cs
@@ -1,6 +1,7 @@
 ﻿using GlmSharp;
 using LanternExtractor.EQ.Wld.Fragments;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace LanternExtractor.EQ.Wld.Helpers
 {

--- a/LanternExtractor/EQ/Wld/WldFile.cs
+++ b/LanternExtractor/EQ/Wld/WldFile.cs
@@ -496,6 +496,7 @@ namespace LanternExtractor.EQ.Wld
                 }
 
                 if (_settings.ExportAdditionalAnimations &&
+                    _settings.ModelExportFormat == ModelExportFormat.Intermediate &&
                     !ZoneShortname.StartsWith("global"))
                 {
                     GlobalReference.CharacterWld.AddAdditionalAnimationsToSkeleton(skeleton);

--- a/LanternExtractor/EQ/Wld/WldFileEquipment.cs
+++ b/LanternExtractor/EQ/Wld/WldFileEquipment.cs
@@ -3,13 +3,14 @@ using LanternExtractor.EQ.Wld.Exporters;
 using LanternExtractor.EQ.Wld.Fragments;
 using LanternExtractor.EQ.Wld.Helpers;
 using LanternExtractor.Infrastructure.Logger;
+using System.Collections.Generic;
 
 namespace LanternExtractor.EQ.Wld
 {
     public class WldFileEquipment : WldFile
     {
         public WldFileEquipment(PfsFile wldFile, string zoneName, WldType type, ILogger logger, Settings settings,
-            WldFile wldToInject = null) : base(wldFile, zoneName, type, logger, settings, wldToInject)
+            List<WldFile> wldFilesToInject = null) : base(wldFile, zoneName, type, logger, settings, wldFilesToInject)
         {
         }
 

--- a/LanternExtractor/EQ/Wld/WldFileZone.cs
+++ b/LanternExtractor/EQ/Wld/WldFileZone.cs
@@ -3,6 +3,8 @@ using LanternExtractor.EQ.Wld.DataTypes;
 using LanternExtractor.EQ.Wld.Exporters;
 using LanternExtractor.EQ.Wld.Fragments;
 using LanternExtractor.Infrastructure.Logger;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace LanternExtractor.EQ.Wld
 {
@@ -31,7 +33,7 @@ namespace LanternExtractor.EQ.Wld
             base.ProcessData();
             LinkBspReferences();
 
-            if (_wldToInject != null)
+            if (_wldFilesToInject != null)
             {
                 ImportVertexColors();
             }
@@ -67,7 +69,9 @@ namespace LanternExtractor.EQ.Wld
 
         private void ImportVertexColors()
         {
-            var colors = _wldToInject.GetFragmentsOfType<VertexColors>();
+            var colors = new List<VertexColors>();
+            
+            _wldFilesToInject?.ForEach(w => colors.AddRange(w?.GetFragmentsOfType<VertexColors>() ?? Enumerable.Empty<VertexColors>()));
 
             if (colors.Count == 0)
             {

--- a/LanternExtractor/EQ/Wld/WldFileZoneObjects.cs
+++ b/LanternExtractor/EQ/Wld/WldFileZoneObjects.cs
@@ -2,6 +2,7 @@
 using LanternExtractor.EQ.Wld.Exporters;
 using LanternExtractor.EQ.Wld.Fragments;
 using LanternExtractor.Infrastructure.Logger;
+using System.Linq;
 
 namespace LanternExtractor.EQ.Wld
 {
@@ -49,9 +50,9 @@ namespace LanternExtractor.EQ.Wld
                 colorWriter.ClearExportData();
             }
             
-            if (_wldToInject != null)
+            if (_wldFilesToInject != null)
             {
-                instanceList = _wldToInject.GetFragmentsOfType<ObjectInstance>();
+                _wldFilesToInject?.ForEach(w => instanceList.AddRange(w?.GetFragmentsOfType<ObjectInstance>() ?? Enumerable.Empty<ObjectInstance>())) ;
 
                 foreach (var instance in instanceList)
                 {

--- a/LanternExtractor/LanternExtractor.cs
+++ b/LanternExtractor/LanternExtractor.cs
@@ -65,6 +65,11 @@ namespace LanternExtractor
                 return;
             }
 
+            if (_settings.ExportAdditionalAnimations && !_settings.RawS3dExtract)
+            {
+                _logger.LogError("Before init");
+                ArchiveExtractor.InitializeSharedCharacterWld("Exports/", _logger, _settings);
+            }
             if (_useMultiProcess && _processCount > 0)
             {
                 List<Task> tasks = new List<Task>();

--- a/LanternExtractor/LanternExtractor.cs
+++ b/LanternExtractor/LanternExtractor.cs
@@ -67,7 +67,6 @@ namespace LanternExtractor
 
             if (_settings.ExportAdditionalAnimations && !_settings.RawS3dExtract)
             {
-                _logger.LogError("Before init");
                 ArchiveExtractor.InitializeSharedCharacterWld("Exports/", _logger, _settings);
             }
             if (_useMultiProcess && _processCount > 0)

--- a/LanternExtractor/LanternExtractor.csproj
+++ b/LanternExtractor/LanternExtractor.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <Compile Include="EqFileHelper.cs" />
     <Compile Include="EQ\ArchiveExtractor.cs" />
+    <Compile Include="EQ\GlobalReference.cs" />
     <Compile Include="EQ\Pfs\PfsArchive.cs" />
     <Compile Include="EQ\Pfs\PfsFile.cs" />
     <Compile Include="EQ\ShortnameHelper.cs" />

--- a/LanternExtractor/Settings.cs
+++ b/LanternExtractor/Settings.cs
@@ -93,6 +93,12 @@ namespace LanternExtractor
         public bool ExportGltfInGlbFormat { get; private set; }
 
         /// <summary>
+        /// For skeletal models, if additional compatible animations are available
+        /// in the global character files, include them in the export
+        /// </summary>
+        public bool ExportAdditionalAnimations { get; private set; }
+
+        /// <summary>
         /// The verbosity of the logger
         /// </summary>
         public int LoggerVerbosity { get; private set; }
@@ -194,6 +200,11 @@ namespace LanternExtractor
             if (parsedSettings.ContainsKey("ExportGltfInGlbFormat"))
             {
                 ExportGltfInGlbFormat = Convert.ToBoolean(parsedSettings["ExportGltfInGlbFormat"]);
+            }
+
+            if (parsedSettings.ContainsKey("ExportAdditionalAnimations"))
+            {
+                ExportAdditionalAnimations = Convert.ToBoolean(parsedSettings["ExportAdditionalAnimations"]);
             }
 
             if (parsedSettings.ContainsKey("LoggerVerbosity"))

--- a/LanternExtractor/settings.txt
+++ b/LanternExtractor/settings.txt
@@ -60,6 +60,17 @@ ExportGltfVertexColors = false
 # (glTF)
 ExportGltfInGlbFormat = false
 
+# Export additional animations
+# For skeletal models, if additional compatible animations are available in the global 
+# character files, include them in the export. Only applicable to OBJ and glTF export
+# if ExportAllAnimationFrames is also true.
+# When using Intermediate export format, this will result in many more (redundant) animation files
+# When using OBJ export format, this will *substantially* increase the number of files created
+# and disk space used
+# When using glTF export format, model file sizes will increase significantly.
+# (Intermediate, OBJ, glTF)
+ExportAdditionalAnimations = false
+
 # The minimum verbosity of the logger
 # 0 = info, 1 = warnings, 2 = errors
 LoggerVerbosity = 2


### PR DESCRIPTION
Features/Bugfixes:
- Animations are now sorted and given a more descriptive name when exporting to glTF. (These were copy/pasted from LanternUnityTools where they had been used in the model viewer.)
- There is a new setting in settings.txt called ExportAdditionalAnimations. This defaults to false. If set to true, when exporting, any character models that have additional animations on compatible skeletons in the global character files will have them pulled in. Any character models that have compatible skeletons with a player character skeleton will now get the full assortment of social emotes. This will result in humanoid character models having in excess of 60 animations. When exporting to glTF, it will increase file sizes significantly. This setting will also affect OBJ animation exporting, which creates a separate file for every animation frame. Your free disk space will evaporate quickly.
- A few zone materials rely on textures exported by the associated zone objects. When exporting to glTF, those textures aren't available when the zone is exported, so cannot be attached to the material. Previously this would produce an error in the log, now it produces a warning with an explanation. The material will show up with a blank texture in the model unless manually corrected. Alternatively, if you're exporting as .gltf separate (not .glb) and export twice without deleting existing images, the image texture should be there to be picked up this time.
Code notes:
- WldFile.cs now holds a list of wld files to inject instead of one. _wldFileToInject is now _wldFilesToInject. All references were updated accordingly.
- If the ExportAdditionalAnimations flag is set, global_chr is initialized with global2_chr, global3_chr, and global4_chr injected into it. A new GlobalReference class holds onto a singleton of this WldFileCharacters so it can be referenced while exporting characters from zone chr files.
- Added an _initialized flag to WldFile to avoid initialization happening more than once.