### PR TITLE
Open EAL files without locking the file for other readers

### DIFF
--- a/LanternExtractor/EQ/Sound/EnvAudio.cs
+++ b/LanternExtractor/EQ/Sound/EnvAudio.cs
@@ -39,7 +39,9 @@ namespace LanternExtractor.EQ.Sound
                 return false;
             }
 
-            _ealFile = new EalFile(_ealFilePath);
+            // Allow other threads to open the same file for reading
+            _ealFile = new EalFile(new FileStream(
+                _ealFilePath, FileMode.Open, FileAccess.Read, FileShare.Read));
 
             if (!_ealFile.Initialize())
             {


### PR DESCRIPTION
I was running an `all` export with multiprocess enabled, and got IO exceptions from trying to access defaults.dat. Opening the file with `FileShare.Read` instead resolved the errors.

I didn't attempt to do any resource management, to match how ealtools operates - that makes sense to me (for a tool that is meant to run once and exit), but I wanted to call that out in case anyone feels it's important to fix.

The full stack trace:
```
Unhandled exception. System.IO.IOException: The process cannot access the file 'C:\EverQuest\defaults.dat' because it is being used by another process.
   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.FileStreamHelpers.ChooseStrategy(FileStream fileStream, String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
   at System.IO.File.Open(String path, FileMode mode)
   at EalTools.EalFile..ctor(String filePath)
   at LanternExtractor.EQ.Sound.EnvAudio.Load(String ealFilePath) in [...]\LanternExtractor\EQ\Sound\EnvAudio.cs:line 42
   at LanternExtractor.EQ.ArchiveExtractor.ExtractSoundData(String shortName, String rootFolder, ILogger logger, Settings settings) in [...]\LanternExtractor\EQ\ArchiveExtractor.cs:line 313
   at LanternExtractor.EQ.ArchiveExtractor.ExtractArchiveZone(String path, String rootFolder, ILogger logger, Settings settings, String shortName, PfsFile wldFileInArchive, PfsArchive s3dArchive) in [...]\LanternExtractor\EQ\ArchiveExtractor.cs:line 144
   at LanternExtractor.EQ.ArchiveExtractor.Extract(String path, String rootFolder, ILogger logger, Settings settings) in [...]\LanternExtractor\EQ\ArchiveExtractor.cs:line 81
   at LanternExtractor.LanternExtractor.Main(String[] args) in [...]\LanternExtractor\LanternExtractor.cs:line 35
```