### PR TITLE
Use System.IO.Compression for decompressing PFS files

### DIFF
--- a/LanternExtractor/LanternExtractor.csproj
+++ b/LanternExtractor/LanternExtractor.csproj
@@ -40,7 +40,6 @@
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="DotNetZip" Version="1.16.0" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
DotNetZip is considered vulnerable and unmaintained according to the linters in Visual Studio.

This PR updates the decompression function to use the facilities already provided by the language library. 

For testing, I have successfully built and executed LanternExtractor, and as part of my own project (which I copied this function to) it works and loads assets.

It requires .NET version 6. I am not sure how to set this to the minimum.